### PR TITLE
Fix Google account login error

### DIFF
--- a/api/src/handlers.ts
+++ b/api/src/handlers.ts
@@ -138,6 +138,7 @@ export const googleSignIn = async (
     created: new Date(),
     email: googleUser.email,
     name: googleUser.name,
+    groups: [],
     google: googleUser.id,
     ...foundUser,
     picture: googleUser.picture || ''


### PR DESCRIPTION
If no groups field is set the getPermissions function can't work since it cannot [read reduce of undefined](https://github.com/LuukvE/Luuk-Accounts/blob/45280623ae2ad917a9e72c32ade4aa91fcbf277a/api/src/helpers.ts#L101)